### PR TITLE
KPMP-1153: Update Docker compose

### DIFF
--- a/delphinus/docker-compose.yml
+++ b/delphinus/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - ${ENV_SHIB_CONF_DIR}/shibboleth2.xml:/etc/shibboleth/shibboleth2.xml
       - ${ENV_WSI_FILES_DIR}:/data/deepZoomImages
       - ${ENV_WSI_ORIG_FILES_DIR}:/data/knowledgeEnvironment/deepZoom
+      - ${ENV_APACHE_CONF_DIR}/delphinus.conf:/etc/httpd/conf.d/delphinus.conf        
     networks:
       local:
         aliases:


### PR DESCRIPTION
Since we won't be using circinus-apache anymore, we need the Apache image to pull in the config that redirects the image links. 