### PR TITLE
Kpmp 1352 modify grok patterns

### DIFF
--- a/ara/fluentd/conf/fluent.conf
+++ b/ara/fluentd/conf/fluent.conf
@@ -13,6 +13,9 @@
       @type grok
       grok_failure_key grokfailure
       <grok>
+        pattern %{TIMESTAMP_ISO8601:time_stamp}%{SPACE}%{LOGLEVEL:log_level}%{SPACE}%{NUMBER:pid}%{SPACE}---%{SPACE}\[\s*%{DATA:threadname}\]%{SPACE}%{DATA:logger}%{SPACE}:%{SPACE}USER\:%{SPACE}userId\:%{SPACE}(?<userID>.*),%{SPACE}firstName\:%{SPACE}(?<firstName>.*),%{SPACE}lastName\:%{SPACE}(?<lastName>.*),%{SPACE}displayName\:%{SPACE}(?<displayName>.*),%{SPACE}email\:%{SPACE}(?<email>.*),%{SPACE}shibId\:%{SPACE}(?<shibId>.*)%{SPACE}\|%{SPACE}PKGID\:%{SPACE}(?<pkgid>.*)%{SPACE}\|%{SPACE}URI\:%{SPACE}(?<uri>.*)%{SPACE}\|%{SPACE}MSG\:%{SPACE}(?<appMessage>.*) 
+      </grok>
+      <grok>
         pattern %{TIMESTAMP_ISO8601:time_stamp}%{SPACE}%{LOGLEVEL:log_level}%{SPACE}%{NUMBER:pid}%{SPACE}---%{SPACE}\[\s*%{DATA:threadname}\]%{SPACE}%{DATA:logger}%{SPACE}:%{SPACE}(?<message>(.|\r|\n)*)
       </grok>
     </parse>
@@ -26,6 +29,9 @@
     <parse>
       @type grok
       grok_failure_key grokfailure
+      <grok>
+        pattern %{TIMESTAMP_ISO8601:time_stamp}%{SPACE}%{LOGLEVEL:log_level}%{SPACE}%{NUMBER:pid}%{SPACE}---%{SPACE}\[\s*%{DATA:threadname}\]%{SPACE}%{DATA:logger}%{SPACE}:%{SPACE}USER\:%{SPACE}userId\:%{SPACE}(?<userID>.*),%{SPACE}firstName\:%{SPACE}(?<firstName>.*),%{SPACE}lastName\:%{SPACE}(?<lastName>.*),%{SPACE}displayName\:%{SPACE}(?<displayName>.*),%{SPACE}email\:%{SPACE}(?<email>.*),%{SPACE}shibId\:%{SPACE}(?<shibId>.*)%{SPACE}\|%{SPACE}PKGID\:%{SPACE}(?<pkgid>.*)%{SPACE}\|%{SPACE}URI\:%{SPACE}(?<uri>.*)%{SPACE}\|%{SPACE}MSG\:%{SPACE}(?<appMessage>.*) 
+      </grok>
       <grok>
         pattern %{TIMESTAMP_ISO8601:time_stamp}%{SPACE}%{LOGLEVEL:log_level}%{SPACE}%{NUMBER:pid}%{SPACE}---%{SPACE}\[\s*%{DATA:threadname}\]%{SPACE}%{DATA:logger}%{SPACE}:%{SPACE}(?<message>(.|\r|\n)*)
       </grok>
@@ -41,6 +47,9 @@
       @type grok
       grok_failure_key grokfailure
       <grok>
+        pattern %{TIMESTAMP_ISO8601:time_stamp}%{SPACE}%{LOGLEVEL:log_level}%{SPACE}%{NUMBER:pid}%{SPACE}---%{SPACE}\[\s*%{DATA:threadname}\]%{SPACE}%{DATA:logger}%{SPACE}:%{SPACE}URI\:%{SPACE}(?<uri>.*)%{SPACE}\|%{SPACE}MSG\:%{SPACE}(?<appMessage>.*) 
+      </grok>
+      <grok>
         pattern %{TIMESTAMP_ISO8601:time_stamp}%{SPACE}%{LOGLEVEL:log_level}%{SPACE}%{NUMBER:pid}%{SPACE}---%{SPACE}\[\s*%{DATA:threadname}\]%{SPACE}%{DATA:logger}%{SPACE}:%{SPACE}(?<message>(.|\r|\n)*)
       </grok>
     </parse>
@@ -54,6 +63,11 @@
     <parse>
       @type grok
       grok_failure_key grokfailure
+      <grok>
+        pattern %{TIMESTAMP_ISO8601:time_stamp}%{SPACE}%{LOGLEVEL:log_level}%{SPACE}%{NUMBER:pid}%{SPACE}---%{SPACE}\[\s*%{DATA:threadname}\]%{SPACE}%{DATA:logger}%{SPACE}:%{SPACE}URI\:%{SPACE}(?<uri>.*)%{SPACE}\|%{SPACE}PKGID\:%{SPACE}(?<pkgid>.*)%{SPACE}\|%{SPACE}MSG\:%{SPACE}(?<appMessage>.*) 
+      </grok>
+      <grok>
+        pattern %{TIMESTAMP_ISO8601:time_stamp}%{SPACE}%{LOGLEVEL:log_level}%{SPACE}%{NUMBER:pid}%{SPACE}---%{SPACE}\[\s*%{DATA:threadname}\]%{SPACE}%{DATA:logger}%{SPACE}:%{SPACE}URI\:%{SPACE}(?<uri>.*)%{SPACE}\|%{SPACE}MSG\:%{SPACE}(?<appMessage>.*) 
       <grok>
         pattern %{TIMESTAMP_ISO8601:time_stamp}%{SPACE}%{LOGLEVEL:log_level}%{SPACE}%{NUMBER:pid}%{SPACE}---%{SPACE}\[\s*%{DATA:threadname}\]%{SPACE}%{DATA:logger}%{SPACE}:%{SPACE}(?<message>(.|\r|\n)*)
       </grok>

--- a/ara/fluentd/conf/fluent.conf
+++ b/ara/fluentd/conf/fluent.conf
@@ -68,6 +68,7 @@
       </grok>
       <grok>
         pattern %{TIMESTAMP_ISO8601:time_stamp}%{SPACE}%{LOGLEVEL:log_level}%{SPACE}%{NUMBER:pid}%{SPACE}---%{SPACE}\[\s*%{DATA:threadname}\]%{SPACE}%{DATA:logger}%{SPACE}:%{SPACE}URI\:%{SPACE}(?<uri>.*)%{SPACE}\|%{SPACE}MSG\:%{SPACE}(?<appMessage>.*) 
+      </grok>
       <grok>
         pattern %{TIMESTAMP_ISO8601:time_stamp}%{SPACE}%{LOGLEVEL:log_level}%{SPACE}%{NUMBER:pid}%{SPACE}---%{SPACE}\[\s*%{DATA:threadname}\]%{SPACE}%{DATA:logger}%{SPACE}:%{SPACE}(?<message>(.|\r|\n)*)
       </grok>

--- a/ara/fluentd/conf/fluent.conf
+++ b/ara/fluentd/conf/fluent.conf
@@ -21,23 +21,6 @@
     </parse>
 </filter>
 
-<filter libra-data>
-    @type parser
-    key_name log
-    reserve_data true
-    reserve_time true
-    <parse>
-      @type grok
-      grok_failure_key grokfailure
-      <grok>
-        pattern %{TIMESTAMP_ISO8601:time_stamp}%{SPACE}%{LOGLEVEL:log_level}%{SPACE}%{NUMBER:pid}%{SPACE}---%{SPACE}\[\s*%{DATA:threadname}\]%{SPACE}%{DATA:logger}%{SPACE}:%{SPACE}USER\:%{SPACE}userId\:%{SPACE}(?<userID>.*),%{SPACE}firstName\:%{SPACE}(?<firstName>.*),%{SPACE}lastName\:%{SPACE}(?<lastName>.*),%{SPACE}displayName\:%{SPACE}(?<displayName>.*),%{SPACE}email\:%{SPACE}(?<email>.*),%{SPACE}shibId\:%{SPACE}(?<shibId>.*)%{SPACE}\|%{SPACE}PKGID\:%{SPACE}(?<pkgid>.*)%{SPACE}\|%{SPACE}URI\:%{SPACE}(?<uri>.*)%{SPACE}\|%{SPACE}MSG\:%{SPACE}(?<appMessage>.*) 
-      </grok>
-      <grok>
-        pattern %{TIMESTAMP_ISO8601:time_stamp}%{SPACE}%{LOGLEVEL:log_level}%{SPACE}%{NUMBER:pid}%{SPACE}---%{SPACE}\[\s*%{DATA:threadname}\]%{SPACE}%{DATA:logger}%{SPACE}:%{SPACE}(?<message>(.|\r|\n)*)
-      </grok>
-    </parse>
-</filter>
-
 <filter eridanus-data>
     @type parser
     key_name log

--- a/orion/docker-compose.dev.yml
+++ b/orion/docker-compose.dev.yml
@@ -48,11 +48,6 @@ services:
       GOOGLE_DRIVE_FOLDER_ID: ${ENV_GOOGLE_DRIVE_FOLDER_ID}
       CLIENT_ID: ${ENV_CLIENT_ID}
     privileged: true
-    logging:
-      driver: "fluentd"
-      options:
-        fluentd-address: "localhost:24224"
-        tag: "orion-data"
     networks:
       local:
         aliases:

--- a/orion/docker-compose.dev.yml
+++ b/orion/docker-compose.dev.yml
@@ -48,6 +48,11 @@ services:
       GOOGLE_DRIVE_FOLDER_ID: ${ENV_GOOGLE_DRIVE_FOLDER_ID}
       CLIENT_ID: ${ENV_CLIENT_ID}
     privileged: true
+    logging:
+      driver: "fluentd"
+      options:
+        fluentd-address: "localhost:24224"
+        tag: "orion-data"
     networks:
       local:
         aliases:


### PR DESCRIPTION
A little background information would be helpful here.

When fluentd applies the grok patterns, it will use the first pattern that it matches and then fall through to lower ones if it doesn't match.  Since Spring logs a bunch of stuff outside what we purposefully log and those statements don't contain the particular information we added to our log messages, they will fall through to the last pattern. 