### PR TITLE
KPMP-1829: Add new redirect for state call

### DIFF
--- a/dataLakeProxyServer/docker-compose.yml
+++ b/dataLakeProxyServer/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
   apache:
     container_name: apache-proxy
-    image: kingstonduo/apache:apache-dl-proxy
+    image: kingstonduo/apache-dl-proxy:2.0
     ports:
       - "80:80"
       - "443:443"

--- a/images/apache/apache-basic/container_files/etc/httpd/conf.d/virt.conf
+++ b/images/apache/apache-basic/container_files/etc/httpd/conf.d/virt.conf
@@ -17,6 +17,7 @@ Listen 443
   
   RewriteEngine	on
   RewriteRule	"^/api/v1/state/events/(.*)$"     "http://state-spring:3060/v1/state/events/$1" [P]
+  RewriteRule	"^/api/v1/state/stateDisplayMap$"     "http://state-spring:3060/v1/state/stateDisplayMap" [P]
   RewriteRule	"^/api/(.*)$"                     "http://spring:3030/$1" [P]
 
   <Directory "/var/www/html">

--- a/images/apache/apache-dl-proxy/container_files/etc/httpd/conf.d/virt.conf
+++ b/images/apache/apache-dl-proxy/container_files/etc/httpd/conf.d/virt.conf
@@ -43,6 +43,7 @@ Listen 443
 
   RewriteEngine	on
   RewriteRule	"^/api/v1/state/events/(.*)$"     "http://state-spring:3060/v1/state/events/$1" [P]
+  RewriteRule	"^/api/v1/state/stateDisplayMap$"     "http://state-spring:3060/v1/state/stateDisplayMap" [P]
   RewriteRule	"^/api/(.*)$"                     "http://spring:3030/$1" [P]
 
 </VirtualHost>


### PR DESCRIPTION
I had to touch the apache config for both local and apache-dl-proxy because I set up the state manager service to be able to return the mapping of states to display text, and the front-end would call this directly.