### PR TITLE
Bring down and up the instances twice on uploader to ensure proper sh…

### DIFF
--- a/scripts/docker_container_reboot.py
+++ b/scripts/docker_container_reboot.py
@@ -24,10 +24,10 @@ def restartContainers():
                 'cd /home/ubuntu/heavens-docker/atlas/repository && ' + composeUp)
     elif "uploader" in environment.lower():
         if "dev" in environment.lower():
-            os.system('cd /home/kpmp-appuser/heavens-docker/ && ./dataLake.sh dev down && ./dataLake.sh dev up')
+            os.system('cd /home/kpmp-appuser/heavens-docker/ && ./dataLake.sh dev down && ./dataLake.sh dev up && ./dataLake.sh dev down && ./dataLake.sh dev up')
         elif "qa" in environment.lower():
-            os.system('cd /home/kpmp-appuser/heavens-docker/ && ./dataLake.sh dev down && ./dataLake.sh dev up')
+            os.system('cd /home/kpmp-appuser/heavens-docker/ && ./dataLake.sh dev down && ./dataLake.sh dev up && ./dataLake.sh dev down && ./dataLake.sh dev up')
         elif "prod" in environment.lower():
-            os.system('cd /home/kpmp-appuser/heavens-docker/ && ./dataLake.sh prod down && ./dataLake.sh prod up')
+            os.system('cd /home/kpmp-appuser/heavens-docker/ && ./dataLake.sh prod down && ./dataLake.sh prod up && ./dataLake.sh dev down && ./dataLake.sh dev up')
 
 


### PR DESCRIPTION
…utdown

I've noticed some curious behavior if certain containers are killed, seems best to just force it down and back up to ensure 'proper' down